### PR TITLE
Switch From Old GOVULNDB Env to -db Flag

### DIFF
--- a/govulncheck/internal/govulncheck.sh.tpl
+++ b/govulncheck/internal/govulncheck.sh.tpl
@@ -7,7 +7,7 @@ PATH=$PATH:$PWD/%go_root%/bin
 
 if [[ "%warn%" == "True" ]] ; then
   # Set the module cache to PWD, so we can download the vulnerability cache
-  GOMODCACHE=$PWD GOROOT=$PWD/%go_root% GOVULNDB=file://$PWD/external/vulndb $TOOL_PATH -mode=binary %srcs% || exit 0
+  GOMODCACHE=$PWD GOROOT=$PWD/%go_root% $TOOL_PATH --db=file://$PWD/external/vulndb --mode=binary %srcs% || exit 0
 else
-  GOMODCACHE=$PWD GOROOT=$PWD/%go_root% GOVULNDB=file://$PWD/external/vulndb $TOOL_PATH -mode=binary %srcs%
+  GOMODCACHE=$PWD GOROOT=$PWD/%go_root% $TOOL_PATH --db=file://$PWD/external/vulndb --mode=binary %srcs%
 fi


### PR DESCRIPTION
They switched from the environment variable to a flag: https://github.com/golang/vuln/commit/9ec79eb220341dae2062dd2b97471b40432cc864